### PR TITLE
Inject configuration based connection strings

### DIFF
--- a/HastaneSistemi/Controllers/AdminController.cs
+++ b/HastaneSistemi/Controllers/AdminController.cs
@@ -4,13 +4,19 @@ using HastaneSistemi.Models;
 using System.Collections.Generic;
 using System;
 using System.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
 
 
 namespace HastaneSistemi.Controllers
 {
     public class AdminController : Controller
     {
-        private readonly string _connectionString = "Data Source=127.0.0.1,1433;Initial Catalog=HastaneDB;User ID=sa;Password=12345;TrustServerCertificate=True;";
+        private readonly string _connectionString;
+
+        public AdminController(IConfiguration configuration)
+        {
+            _connectionString = configuration.GetConnectionString("HastaneDB");
+        }
 
         public IActionResult AdminPanel()
         {

--- a/HastaneSistemi/Controllers/DoktorController.cs
+++ b/HastaneSistemi/Controllers/DoktorController.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System;
 using HastaneSistemi.Models;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 
 
@@ -12,7 +13,12 @@ namespace HastaneSistemi.Controllers
 {
     public class DoktorController : Controller
     {
-        private readonly string _connectionString = "Data Source=127.0.0.1,1433\\SQLEXPRESS;Initial Catalog=HastaneDB;User ID=sa;Password=12345;TrustServerCertificate=True;";
+        private readonly string _connectionString;
+
+        public DoktorController(IConfiguration configuration)
+        {
+            _connectionString = configuration.GetConnectionString("HastaneDB");
+        }
 
         public IActionResult DoktorPanel()
         {

--- a/HastaneSistemi/Controllers/HastaController.cs
+++ b/HastaneSistemi/Controllers/HastaController.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Reflection;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 
 
@@ -22,14 +23,13 @@ namespace HastaneSistemi.Controllers
 {
     public class HastaController : Controller
     {
-        private readonly string _connectionString = "Data Source=127.0.0.1,1433;Initial Catalog=HastaneDB;User ID=sa;Password=12345;TrustServerCertificate=True;";
+        private readonly string _connectionString;
         private readonly HastaneDbContext _context;
 
-        
-
-        public HastaController(HastaneDbContext context)
+        public HastaController(HastaneDbContext context, IConfiguration configuration)
         {
             _context = context;
+            _connectionString = configuration.GetConnectionString("HastaneDB");
         }
 
 


### PR DESCRIPTION
## Summary
- inject `IConfiguration` to AdminController, HastaController and DoktorController
- use configuration based connection string in controllers

## Testing
- `dotnet build HastaneSistemi/HastaneSistemi.csproj -warnaserror` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b44e1708331a91a5671f5632380